### PR TITLE
AIRO-1486: Destroy vhacd instance

### DIFF
--- a/com.unity.robotics.vhacd/Runtime/VHACD.cs
+++ b/com.unity.robotics.vhacd/Runtime/VHACD.cs
@@ -186,6 +186,8 @@ namespace MeshProcess
 
                 convexMesh.Add(hullMesh);
             }
+
+            DestroyVHACD(vhacd);
             return convexMesh;
         }
     }


### PR DESCRIPTION
## Proposed change(s)

Destroy `vhacd` instance to prevent memory leak.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/VHACD-deprecated/pull/7

### Types of change(s)

- [x] Bug fix